### PR TITLE
Fixing error while getting Client Image - skipErrorHandler() is not defined for HttpClient and hence giving error while getting Client Image

### DIFF
--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -170,9 +170,7 @@ export class ClientsService {
 
   getClientProfileImage(clientId: string) {
     const httpParams = new HttpParams().set('maxHeight', '150');
-    return this.http
-      .skipErrorHandler()
-      .get(`/clients/${clientId}/images`, { params: httpParams, responseType: 'text' });
+    return this.http.get(`/clients/${clientId}/images`, { params: httpParams, responseType: 'text' });
   }
 
   uploadClientProfileImage(clientId: string, image: File) {


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
